### PR TITLE
Small compilation tweaks

### DIFF
--- a/c10m/c10m.c
+++ b/c10m/c10m.c
@@ -46,7 +46,7 @@ void stack_use(long totalkb) {
   size_t page_size = 4096;
   size_t total_pages = ((size_t)totalkb*1024 + page_size - 1) / page_size;
   for (size_t i = 0; i < total_pages; i++) {
-    volatile uint8_t b = *(sp - (i * page_size));
+     __attribute__ ((unused)) volatile uint8_t b = *(sp - (i * page_size));
   }
 }
 
@@ -81,8 +81,8 @@ uint32_t async_wl(void) {
     count += resume_async_worker(j, stack_kb); // do the work
     free_async_worker(j);
   }
-  size_t total_kb = total_conn * stack_kb;
-  double total_mb = (double)(total_conn * stack_kb) / 1024.0;
+   __attribute__ ((unused)) size_t total_kb = total_conn * stack_kb;
+   __attribute__ ((unused)) double total_mb = (double)(total_conn * stack_kb) / 1024.0;
   //printf("total stack used: %.3fmb, count=%" PRIu32 "\n", total_mb, count);
   return count;
 }

--- a/c10m/c10m.c
+++ b/c10m/c10m.c
@@ -81,8 +81,8 @@ uint32_t async_wl(void) {
     count += resume_async_worker(j, stack_kb); // do the work
     free_async_worker(j);
   }
-   __attribute__ ((unused)) size_t total_kb = total_conn * stack_kb;
-   __attribute__ ((unused)) double total_mb = (double)(total_conn * stack_kb) / 1024.0;
+  // size_t total_kb = total_conn * stack_kb;
+  // double total_mb = (double)(total_conn * stack_kb) / 1024.0;
   //printf("total stack used: %.3fmb, count=%" PRIu32 "\n", total_mb, count);
   return count;
 }

--- a/c10m/c10m_bespoke.c
+++ b/c10m/c10m_bespoke.c
@@ -50,7 +50,7 @@ uint32_t resume_async_worker(uint32_t key, uint32_t value) {
 
 extern
 __attribute__((import_module("env"), import_name("free_async_worker")))
-void free_async_worker(uint32_t _unused) {}
+void free_async_worker(__attribute__ ((unused)) uint32_t _unused) {}
 
 static
 __attribute__((noinline))
@@ -72,7 +72,7 @@ void stack_use(long totalkb) {
   size_t page_size = 4096;
   size_t total_pages = ((size_t)totalkb*1024 + page_size - 1) / page_size;
   for (size_t i = 0; i < total_pages; i++) {
-    volatile uint8_t b = *(sp - (i * page_size));
+     __attribute__ ((unused)) volatile uint8_t b = *(sp - (i * page_size));
   }
 }
 
@@ -118,8 +118,8 @@ uint32_t async_wl(void) {
     count += resume_async_worker(j, stack_kb); // do the work
     free_async_worker(j);
   }
-  size_t total_kb = total_conn * stack_kb;
-  double total_mb = (double)(total_conn * stack_kb) / 1024.0;
+   __attribute__ ((unused)) size_t total_kb = total_conn * stack_kb;
+   __attribute__ ((unused)) double total_mb = (double)(total_conn * stack_kb) / 1024.0;
   //printf("total stack used: %.3fmb, count=%" PRIu32 "\n", total_mb, count);
   return (uint32_t)count;
 }

--- a/c10m/c10m_bespoke.c
+++ b/c10m/c10m_bespoke.c
@@ -118,8 +118,8 @@ uint32_t async_wl(void) {
     count += resume_async_worker(j, stack_kb); // do the work
     free_async_worker(j);
   }
-   __attribute__ ((unused)) size_t total_kb = total_conn * stack_kb;
-   __attribute__ ((unused)) double total_mb = (double)(total_conn * stack_kb) / 1024.0;
+  // size_t total_kb = total_conn * stack_kb;
+  // double total_mb = (double)(total_conn * stack_kb) / 1024.0;
   //printf("total stack used: %.3fmb, count=%" PRIu32 "\n", total_mb, count);
   return (uint32_t)count;
 }

--- a/c10m/parameters.h
+++ b/c10m/parameters.h
@@ -11,7 +11,7 @@ static const uint32_t stack_kb = 32;
 
 static const uint32_t reference = 10010000;
 
-static int verify(const uint32_t my_count, const uint32_t reference) {
+ __attribute__ ((unused)) static int verify(const uint32_t my_count, const uint32_t reference) {
   if (my_count == reference) return 0;
   else return 1;
 }

--- a/harness.py
+++ b/harness.py
@@ -171,7 +171,7 @@ class MakeWasm(Benchmark):
             cwd=suite_path,
         )
 
-        wasmtime.compileWasm(suite_path / wasm_file, output_dir / cwasm_file)
+        wasmtime.compileWasm(suite_path / wasm_make_target, output_dir / cwasm_file)
 
         run_command = wasmtime.shellCommandCwasmRun(output_dir / cwasm_file)
         return mimalloc.addToShellCommmand(run_command)

--- a/harness.py
+++ b/harness.py
@@ -152,6 +152,7 @@ class MakeWasm(Benchmark):
         wasmtime,
     ):
         wasm_file = self.file + ".wasm"
+        wasm_make_target = Path("out") / wasm_file
         cwasm_file = self.file + ".cwasm"
         suite_path = Path(suite.path)
         interpreter = Path(reference_interpreter.executablePath()).absolute()
@@ -160,7 +161,7 @@ class MakeWasm(Benchmark):
         wasm_opt = binaryen.wasmOptExecutablePath().absolute()
         runCheck("make clean", cwd=suite_path)
         runCheck(
-            ["make", wasm_file]
+            ["make", str(wasm_make_target)]
             + [
                 f"WASICC={wasi_cc}",
                 f"WASM_INTERP={interpreter}",

--- a/make.config
+++ b/make.config
@@ -6,7 +6,7 @@ MIMALLOC=../mimalloc-2.1.2/release/out/libmimalloc.so
 
 # WASI SDK C/C++ compiler
 WASICC?=../wasi-sdk-22.0/bin/clang
-WASICC_FLAGS=-O3 -Wall -Wextra -Werror -DDEFAULT_STACK_SIZE=$(DEFAULT_STACK_SIZE)
+WASICC_FLAGS=--std=c17 -O3 -Wall -Wextra -Werror -DDEFAULT_STACK_SIZE=$(DEFAULT_STACK_SIZE)
 
 # Wabt
 WABTFX_FLAGS=--enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-typed-continuations

--- a/make.config
+++ b/make.config
@@ -6,7 +6,7 @@ MIMALLOC=../mimalloc-2.1.2/release/out/libmimalloc.so
 
 # WASI SDK C/C++ compiler
 WASICC?=../wasi-sdk-22.0/bin/clang
-WASICC_FLAGS=-O3 -DDEFAULT_STACK_SIZE=$(DEFAULT_STACK_SIZE)
+WASICC_FLAGS=-O3 -Wall -Wextra -Werror -DDEFAULT_STACK_SIZE=$(DEFAULT_STACK_SIZE)
 
 # Wabt
 WABTFX_FLAGS=--enable-exception-handling --enable-reference-types --enable-multivalue --enable-bulk-memory --enable-gc --enable-typed-continuations

--- a/make.generic.config
+++ b/make.generic.config
@@ -3,48 +3,51 @@ CONFIG=../make.config
 include ${CONFIG}
 
 .PHONY: all
-all: $(BENCHMARK)_bespoke.cwasm $(BENCHMARK)_asyncify.cwasm $(BENCHMARK)_wasmfx.cwasm
+all: out/$(BENCHMARK)_bespoke.cwasm out/$(BENCHMARK)_asyncify.cwasm out/$(BENCHMARK)_wasmfx.cwasm
 
-$(BENCHMARK)_bespoke.wasm: $(BENCHMARK)_bespoke.c
-	$(WASICC) $(WASICC_FLAGS) -o $(BENCHMARK)_bespoke.wasm $(BENCHMARK)_bespoke.c
+out/$(BENCHMARK)_bespoke.wasm: $(BENCHMARK)_bespoke.c
+	mkdir -p out
+	$(WASICC) $(WASICC_FLAGS) -o out/$(BENCHMARK)_bespoke.wasm $(BENCHMARK)_bespoke.c
 
-$(BENCHMARK)_bespoke.cwasm: $(BENCHMARK)_bespoke.wasm
-	$(WASMTIMEC) -o $(BENCHMARK)_bespoke.cwasm $(BENCHMARK)_bespoke.wasm
+out/$(BENCHMARK)_bespoke.cwasm: out/$(BENCHMARK)_bespoke.wasm
+	$(WASMTIMEC) -o out/$(BENCHMARK)_bespoke.cwasm $(BENCHMARK)_bespoke.wasm
 
-$(BENCHMARK)_asyncify.wasm: $(BENCHMARK).c asyncify.c
-	$(WASICC) $(WASICC_FLAGS) -I ../fiber/ -o $(BENCHMARK)_asyncify.pre.wasm ../fiber/fiber_asyncify.c asyncify.c $(BENCHMARK).c
-	$(ASYNCIFY) $(BENCHMARK)_asyncify.pre.wasm -o $(BENCHMARK)_asyncify.wasm
+out/$(BENCHMARK)_asyncify.wasm: $(BENCHMARK).c asyncify.c
+	mkdir -p out
+	$(WASICC) $(WASICC_FLAGS) -I ../fiber/ -o out/$(BENCHMARK)_asyncify.pre.wasm ../fiber/fiber_asyncify.c asyncify.c $(BENCHMARK).c
+	$(ASYNCIFY) out/$(BENCHMARK)_asyncify.pre.wasm -o out/$(BENCHMARK)_asyncify.wasm
 
-$(BENCHMARK)_asyncify.cwasm: $(BENCHMARK)_asyncify.wasm
-	$(WASMTIMEC) -o $(BENCHMARK)_asyncify.cwasm $(BENCHMARK)_asyncify.wasm
+out/$(BENCHMARK)_asyncify.cwasm: out/$(BENCHMARK)_asyncify.wasm
+	$(WASMTIMEC) -o out/$(BENCHMARK)_asyncify.cwasm out/$(BENCHMARK)_asyncify.wasm
 
-$(BENCHMARK)_wasmfx.wasm: $(BENCHMARK).c wasmfx_import.wast
-	$(WASICC) $(WASICC_FLAGS) -I ../fiber/ -o $(BENCHMARK)_wasmfx.pre.wasm $(BENCHMARK).c
-	$(WASM_INTERP) -d -i wasmfx_import.wast -o wasmfx_import.wasm
-	$(WASMFX_MERGE) wasmfx_import.wasm "impl" $(BENCHMARK)_wasmfx.pre.wasm "benchmark" -o $(BENCHMARK)_wasmfx-merged.wasm
-	mv $(BENCHMARK)_wasmfx-merged.wasm $(BENCHMARK)_wasmfx.wasm # TODO(dhil): use wasm-opt once it supports WasmFX instructions.
+out/$(BENCHMARK)_wasmfx.wasm: $(BENCHMARK).c wasmfx_import.wast
+	mkdir -p out
+	$(WASICC) $(WASICC_FLAGS) -I ../fiber/ -o out/$(BENCHMARK)_wasmfx.pre.wasm $(BENCHMARK).c
+	$(WASM_INTERP) -d -i wasmfx_import.wast -o out/wasmfx_import.wasm
+	$(WASMFX_MERGE) out/wasmfx_import.wasm "impl" out/$(BENCHMARK)_wasmfx.pre.wasm "benchmark" -o out/$(BENCHMARK)_wasmfx-merged.wasm
+	mv out/$(BENCHMARK)_wasmfx-merged.wasm out/$(BENCHMARK)_wasmfx.wasm # TODO(dhil): use wasm-opt once it supports WasmFX instructions.
 
-$(BENCHMARK)_wasmfx.cwasm: $(BENCHMARK)_wasmfx.wasm
-	$(WASMFXTIMEC) -o $(BENCHMARK)_wasmfx.cwasm $(BENCHMARK)_wasmfx.wasm
+out/$(BENCHMARK)_wasmfx.cwasm: out/$(BENCHMARK)_wasmfx.wasm
+	$(WASMFXTIMEC) -o out/$(BENCHMARK)_wasmfx.cwasm out/$(BENCHMARK)_wasmfx.wasm
 
 .PHONY: bench
-bench: $(BENCHMARK)_bespoke.cwasm $(BENCHMARK)_asyncify.cwasm $(BENCHMARK)_wasmfx.cwasm
-	$(HYPERFINE) "$(WASMTIMEC_RUN) $(BENCHMARK)_bespoke.cwasm" "$(WASMTIMEC_RUN) $(BENCHMARK)_asyncify.cwasm" "$(WASMFXTIMEC_RUN) $(BENCHMARK)_wasmfx.cwasm"
+bench: out/$(BENCHMARK)_bespoke.cwasm out/$(BENCHMARK)_asyncify.cwasm out/$(BENCHMARK)_wasmfx.cwasm
+	$(HYPERFINE) "$(WASMTIMEC_RUN) out/$(BENCHMARK)_bespoke.cwasm" "$(WASMTIMEC_RUN) out/$(BENCHMARK)_asyncify.cwasm" "$(WASMFXTIMEC_RUN) out/$(BENCHMARK)_wasmfx.cwasm"
 
 .PHONY: benchfx
-benchfx: $(BENCHMARK)_asyncify.cwasm $(BENCHMARK)_wasmfx.cwasm
-	$(HYPERFINE) "$(WASMTIMEC_RUN) $(BENCHMARK)_asyncify.cwasm" "$(WASMFXTIMEC_RUN) $(BENCHMARK)_wasmfx.cwasm"
+benchfx: out/$(BENCHMARK)_asyncify.cwasm out/$(BENCHMARK)_wasmfx.cwasm
+	$(HYPERFINE) "$(WASMTIMEC_RUN) out/$(BENCHMARK)_asyncify.cwasm" "$(WASMFXTIMEC_RUN) out/$(BENCHMARK)_wasmfx.cwasm"
 
 .PHONY: bench-mem
-bench-mem: $(BENCHMARK)_bespoke.cwasm $(BENCHMARK)_asyncify.cwasm $(BENCHMARK)_wasmfx.cwasm
-	/usr/bin/time -f ' bespoke: %M' $(WASMTIMEC_RUN) $(BENCHMARK)_bespoke.cwasm
-	/usr/bin/time -f 'asyncify: %M' $(WASMTIMEC_RUN) $(BENCHMARK)_asyncify.cwasm
-	/usr/bin/time -f '  wasmfx: %M' $(WASMFXTIMEC_RUN) $(BENCHMARK)_wasmfx.cwasm
+bench-mem: out/$(BENCHMARK)_bespoke.cwasm out/$(BENCHMARK)_asyncify.cwasm out/$(BENCHMARK)_wasmfx.cwasm
+	/usr/bin/time -f ' bespoke: %M' $(WASMTIMEC_RUN) out/$(BENCHMARK)_bespoke.cwasm
+	/usr/bin/time -f 'asyncify: %M' $(WASMTIMEC_RUN) out/$(BENCHMARK)_asyncify.cwasm
+	/usr/bin/time -f '  wasmfx: %M' $(WASMFXTIMEC_RUN) out/$(BENCHMARK)_wasmfx.cwasm
 
 .PHONY: benchfx-mem
-benchfx-mem: $(BENCHMARK)_asyncify.cwasm $(BENCHMARK)_wasmfx.cwasm
-	/usr/bin/time -f 'asyncify: %M' $(WASMTIMEC_RUN) $(BENCHMARK)_asyncify.cwasm
-	/usr/bin/time -f '  wasmfx: %M' $(WASMFXTIMEC_RUN) $(BENCHMARK)_wasmfx.cwasm
+benchfx-mem: out/$(BENCHMARK)_asyncify.cwasm out/$(BENCHMARK)_wasmfx.cwasm
+	/usr/bin/time -f 'asyncify: %M' $(WASMTIMEC_RUN) out/$(BENCHMARK)_asyncify.cwasm
+	/usr/bin/time -f '  wasmfx: %M' $(WASMFXTIMEC_RUN) out/$(BENCHMARK)_wasmfx.cwasm
 
 .PHONY: grant-perf-privileges
 grant-perf-privileges:
@@ -55,11 +58,9 @@ revoke-perf-privileges:
 	sudo sysctl -w kernel.perf_event_paranoid=0
 
 .PHONY: perf-wasmfx
-perf-wasmfx: $(BENCHMARK)_wasmfx.cwasm
-	sudo perf record -k mono $(WASMFXTIMEC_RUN) --profile=perfmap $(BENCHMARK)_wasmfx.cwasm
+perf-wasmfx: out/$(BENCHMARK)_wasmfx.cwasm
+	sudo perf record -k mono $(WASMFXTIMEC_RUN) --profile=perfmap out/$(BENCHMARK)_wasmfx.cwasm
 
 .PHONY: clean
 clean:
-	rm -f wasmfx_import.wasm
-	rm -f $(BENCHMARK)_asyncify.pre.wasm $(BENCHMARK)_asyncify.wasm $(BENCHMARK)_bespoke.wasm $(BENCHMARK)_wasmfx.wasm $(BENCHMARK)_wasmfx-merged.wasm
-	rm -f $(BENCHMARK)_asyncify.cwasm $(BENCHMARK)_bespoke.cwasm $(BENCHMARK)_wasmfx.cwasm
+	test -d out && rm -r out || true

--- a/make.generic.config
+++ b/make.generic.config
@@ -10,7 +10,7 @@ out/$(BENCHMARK)_bespoke.wasm: $(BENCHMARK)_bespoke.c
 	$(WASICC) $(WASICC_FLAGS) -o out/$(BENCHMARK)_bespoke.wasm $(BENCHMARK)_bespoke.c
 
 out/$(BENCHMARK)_bespoke.cwasm: out/$(BENCHMARK)_bespoke.wasm
-	$(WASMTIMEC) -o out/$(BENCHMARK)_bespoke.cwasm $(BENCHMARK)_bespoke.wasm
+	$(WASMTIMEC) -o out/$(BENCHMARK)_bespoke.cwasm out/$(BENCHMARK)_bespoke.wasm
 
 out/$(BENCHMARK)_asyncify.wasm: $(BENCHMARK).c asyncify.c
 	mkdir -p out


### PR DESCRIPTION
This PR makes two small changes to the compilation of benchmarks:

1. `WASICC_FLAGS` now also contains `-Wall`, `-Wextra`, and `-Werror`, meaning that these are passed to `clang` when compiling C to wasm. This required some minor changes to existing benchmark definitions due to unused variables and functions.
2. `make.generic.config` now puts all compilation artifacts into `out` subfolders in each benchmark subdirectory. This makes it easier to distinguish source files from generated ones (for example, when automatically converting compiled `.wasm` files back to `.wat` for debugging purposes)