### PR TITLE
Misc harness improvements

### DIFF
--- a/harness.py
+++ b/harness.py
@@ -712,7 +712,7 @@ def checkBenchFxRepoClean():
 
 def checkDependenciesPresent(need_second_wasmtime_repo):
     def checkExternalToolsPresent():
-        tools = ["make", "cmake", "dune", "hyperfine"]
+        tools = ["make", "cmake", "dune", "hyperfine", "cargo"]
         for tool in tools:
             runCheck(
                 f"command -v {tool}",
@@ -1154,3 +1154,4 @@ if __name__ == "__main__":
     except HarnessError as e:
         print("Error: " + e.args[0])
         logProcessOutput(traceback.format_exc())
+        sys.exit(1)

--- a/harness.py
+++ b/harness.py
@@ -174,7 +174,11 @@ class MakeWasm(Benchmark):
         wasmtime.compileWasm(suite_path / wasm_make_target, output_dir / cwasm_file)
 
         run_command = wasmtime.shellCommandCwasmRun(output_dir / cwasm_file)
-        return mimalloc.addToShellCommmand(run_command)
+        return (
+            mimalloc.addToShellCommmand(run_command)
+            if config.use_mimalloc
+            else run_command
+        )
 
 
 class Wat(Benchmark):
@@ -214,7 +218,11 @@ class Wat(Benchmark):
             cwasm_path, invoke_function=self.invoke
         )
 
-        return mimalloc.addToShellCommmand(run_command)
+        return (
+            mimalloc.addToShellCommmand(run_command)
+            if config.use_mimalloc
+            else run_command
+        )
 
 
 def run(cmd: str | List[str], cwd=None) -> subprocess.CompletedProcess:

--- a/harness.py
+++ b/harness.py
@@ -658,6 +658,20 @@ def prepareCommonTools() -> Tuple[WasiSdk, Mimalloc, ReferenceInterpreter, Binar
     return (wasi_sdk, mimalloc, interpreter, binaryen)
 
 
+def addSharedArgsToSubparser(parser):
+    parser.add_argument(
+        "--filter",
+        help="Only run benchmarks that match this glob pattern",
+        action="append",
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        help="Allows the benchfx repo to be dirty when running benchmarks",
+        action="store_true",
+        default=False,
+    )
+
+
 def addRevisionSpecificArgsToSubparser(
     subparser,
     revision_qualifier: Optional[str] = None,
@@ -775,17 +789,6 @@ class SubcommandRun:
         parser = subparsers.add_parser("run", help="runs benchmarks (used by default)")
 
         parser.add_argument(
-            "--filter",
-            help="Only run benchmarks that match this glob pattern",
-            action="append",
-        )
-        parser.add_argument(
-            "--allow-dirty",
-            help="Allows the benchfx repo to be dirty when running benchmarks",
-            action="store_true",
-            default=False,
-        )
-        parser.add_argument(
             "wasmtime_rev",
             help="Instead of config.WASMTIME_REVISION, use this wasmtime revision instead (optional)",
             action="store",
@@ -793,6 +796,7 @@ class SubcommandRun:
             nargs="?",
         )
 
+        addSharedArgsToSubparser(parser)
         addRevisionSpecificArgsToSubparser(parser)
 
     def execute(self, cli_args: argparse.Namespace):
@@ -876,23 +880,13 @@ class SubcommandCompareRevs:
             first revision of wasmtime against second one""",
         )
         parser.add_argument(
-            "--filter",
-            help="Only run benchmarks that match this glob pattern",
-            action="append",
-        )
-        parser.add_argument(
-            "--allow-dirty",
-            help="Allows the benchfx repo to be dirty when running benchmarks",
-            action="store_true",
-            default=False,
-        )
-        parser.add_argument(
             "revision1", help="First Wasmtime revision to use in the comparison"
         )
         parser.add_argument(
             "revision2", help="Second Wasmtime revision to use in the comparison"
         )
 
+        addSharedArgsToSubparser(parser)
         addRevisionSpecificArgsToSubparser(
             parser, revision_qualifier="rev1", desc="revision 1"
         )


### PR DESCRIPTION
This PR just collects a few uncontroversial fixes and improvements of the benchmark harness:
- For benchmarks built using `make.generic.config`, allow specifying additional arguments passed to `make` as part of the benchmark's definition (useful for defining variants of the same benchmark)
- Use hyperfine's `--comand-name` option to give useful names to the shell commands it compares. Thus, instead of printing the lengthy shell commands in the Summary table produced by hyperfine, it now shows the benchmark names instead
- Add `--prepare-only` flag which makes the harness perform all preparation/compilation steps, but stop before actually running benchmarks
- Some minor cleanup about the configuration of CLI arguments
- Actually respect the `use-mimalloc` CLI flag
- Exit with non-zero exit code if there was an error
- add `cargo` to the list of helper tools that we look for in `$PATH` and complain if they are missing