### PR TITLE
Fix treatment of empty CLI args

### DIFF
--- a/harness.py
+++ b/harness.py
@@ -369,7 +369,9 @@ class Config:
         for prop_name, parser in prop_parsers:
             qualified_attr_name = prefix + prop_name
             attr_val = getattr(cli_args, qualified_attr_name, None)
-            val = parser(qualified_attr_name, attr_val) if attr_val is not None else None
+            val = (
+                parser(qualified_attr_name, attr_val) if attr_val is not None else None
+            )
             setattr(config, prop_name, val)
 
         return config

--- a/harness.py
+++ b/harness.py
@@ -369,7 +369,7 @@ class Config:
         for prop_name, parser in prop_parsers:
             qualified_attr_name = prefix + prop_name
             attr_val = getattr(cli_args, qualified_attr_name, None)
-            val = parser(qualified_attr_name, attr_val) if attr_val else None
+            val = parser(qualified_attr_name, attr_val) if attr_val is not None else None
             setattr(config, prop_name, val)
 
         return config


### PR DESCRIPTION
The harness was ignoring empty CLI arguments, treating them the same as if they were not given at all.
Meaning that the following were treated the same, even though they aren't
```
./harness run --wasmtime-cargo-build-args=""
./harness run
```