### PR TITLE
Features for regression testing in Wasmtime CI

### DIFF
--- a/harness.py
+++ b/harness.py
@@ -2,6 +2,7 @@
 
 import argparse
 import config
+import datetime
 import json
 import multiprocessing
 import os
@@ -39,13 +40,15 @@ logLevel = 0
 
 
 def logProcessOutput(msg, sep=None):
+    now = datetime.datetime.now()
     if logLevel > 1:
-        print(msg, sep=sep)
+        print(f"{now}: ", msg, sep=sep)
 
 
 def logMsg(msg, sep=None):
+    now = datetime.datetime.now()
     if logLevel > 0:
-        print(msg, sep=sep)
+        print(f"{now}: ", msg, sep=sep)
 
 
 @dataclass

--- a/harness.py
+++ b/harness.py
@@ -1224,7 +1224,7 @@ class SubcommandPrintConfig:
     def execute(self, cli_args: argparse.Namespace):
         class CustomEncoder(json.JSONEncoder):
             def default(self, o):
-                if dataclasses.is_dataclass(o):
+                if dataclasses.is_dataclass(o) and not isinstance(o, type):
                     return dataclasses.asdict(o)
                 else:
                     return super().default(o)

--- a/harness.py
+++ b/harness.py
@@ -268,22 +268,33 @@ def runCheck(cmd, msg=None, cwd=None):
 class Binaryen:
     path: Path
 
+    def _build_path(self):
+        return self.path / "build"
+
     def build(self):
         cpus = multiprocessing.cpu_count()
+
+        runCheck(
+            f"mkdir -p build",
+            cwd=self.path,
+        )
+
         # TODO(frank-emrich) Build with clang until the following is fixed:
         # https://github.com/WebAssembly/binaryen/issues/6779
         runCheck(
-            "cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .",
+            "cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -S .. -B .",
             msg="cmake for binaryen failed",
-            cwd=self.path,
+            cwd=self._build_path(),
         )
-        runCheck(f"make -j {cpus}", msg="building binaryen failed", cwd=self.path)
+        runCheck(
+            f"make -j {cpus}", msg="building binaryen failed", cwd=self._build_path()
+        )
 
     def wasmMergeExecutablePath(self) -> Path:
-        return self.path / "bin" / "wasm-merge"
+        return self._build_path() / "bin" / "wasm-merge"
 
     def wasmOptExecutablePath(self) -> Path:
-        return self.path / "bin" / "wasm-opt"
+        return self._build_path() / "bin" / "wasm-opt"
 
 
 class Mimalloc:

--- a/micro/2resumes_same_function/bench.wat
+++ b/micro/2resumes_same_function/bench.wat
@@ -5,7 +5,7 @@
 
  (tag $t)
 
- (global $iterations i32 (i32.const 100000000))
+ (global $iterations i32 (i32.const 20000000))
 
  (func $suspend0
    (local $i i32)

--- a/micro/suspend_resume/bench.wat
+++ b/micro/suspend_resume/bench.wat
@@ -5,7 +5,7 @@
 
  (tag $tr0s0)
 
- (global $iterations i32 (i32.const 100000000))
+ (global $iterations i32 (i32.const 20000000))
 
  (func $suspend0
    (local $i i32)


### PR DESCRIPTION
This PR just collects four convenience features that make it easier to use the harness for automated regression testing as part of the Wasmtime CI:

1. Printing timestamps when logging in verbose mode. Allows figuring out what build steps take how long.
2. No longer perform in-tree builds of binaryen. Using a dedicated `build` dir for artifacts makes caching them easier.
3. A new subcommand `print-config` that dumps a JSON representation of the settings in `config.py`. Makes automation simpler.
4. Reduce the number of iterations performed in the micro benchmarks. Their runtime was previously ~6 seconds, which is a bit excessive. The new runtime is ~1.5 seconds, in line with most other benchmarks.